### PR TITLE
feat: add Instagram user profile embeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log*
 .claude/
 .agents/
 skills-lock.json
+.reference/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "wrangler dev",
-    "build": "vite build --config web/vite.config.ts",
+    "build": "vite build --config web/vite.config.ts && node web/hash-favicons.mjs",
     "check": "tsc -p tsconfig.json --noEmit && tsc -p web/tsconfig.json --noEmit && cd server && go test ./...",
     "secrets": "wrangler secret bulk .env",
     "preview": "wrangler versions upload",

--- a/server/app.go
+++ b/server/app.go
@@ -32,6 +32,12 @@ type App struct {
 
 	inflightMu sync.Mutex
 	inflight   map[string]*inflightCall
+
+	profileMu       sync.Mutex
+	profiles        map[string]*profileEntry
+	profileOrder    []string
+	profileFlightMu sync.Mutex
+	profileFlight   map[string]*profileCall
 }
 
 func newApp(cfg Config, pool *SessionPool, assets *Assets) *App {
@@ -47,8 +53,10 @@ func newApp(cfg Config, pool *SessionPool, assets *Assets) *App {
 				ForceAttemptHTTP2:   true,
 			},
 		},
-		cache:    map[string]*cacheEntry{},
-		inflight: map[string]*inflightCall{},
+		cache:         map[string]*cacheEntry{},
+		inflight:      map[string]*inflightCall{},
+		profiles:      map[string]*profileEntry{},
+		profileFlight: map[string]*profileCall{},
 	}
 }
 
@@ -100,10 +108,11 @@ func (a *App) getEntry(shortcode string, meta *fetchMeta) (*cacheEntry, *AppErro
 func (a *App) fetchEntry(shortcode string) (*cacheEntry, *AppError) {
 	post, err := a.fetchPost(shortcode)
 	if err != nil {
-		if isTransientStatus(err.Status) {
+		if err.Ephemeral {
 			return nil, err
 		}
-		entry := &cacheEntry{err: err, expiresAt: time.Now().Add(negativeCacheTTL)}
+		ttl := time.Duration(errorCacheSeconds(err.Reason)) * time.Second
+		entry := &cacheEntry{err: err, expiresAt: time.Now().Add(ttl)}
 		return a.storeEntry(shortcode, entry), err
 	}
 	entry := &cacheEntry{post: post, expiresAt: time.Now().Add(time.Duration(a.cfg.CacheTTLSeconds) * time.Second)}

--- a/server/assets.go
+++ b/server/assets.go
@@ -3,8 +3,11 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+var faviconRE = regexp.MustCompile(`^favicon-(\d+)(-[0-9a-f]+)?\.png$`)
 
 type assetFile struct {
 	contentType string
@@ -16,7 +19,15 @@ type Assets struct {
 	homeTemplate string
 	mainJS       string
 	mainCSS      string
+	favicons     map[string]string // size -> "/favicon-<size>-<hash>.png"
 	files        map[string]assetFile
+}
+
+func (a *Assets) faviconPath(size string) string {
+	if p, ok := a.favicons[size]; ok {
+		return p
+	}
+	return "/favicon-" + size + ".png"
 }
 
 func contentTypeFor(name string) string {
@@ -39,7 +50,7 @@ func loadAssets(dir string) (*Assets, error) {
 	if err != nil {
 		return nil, err
 	}
-	a := &Assets{homeTemplate: string(home), files: map[string]assetFile{}}
+	a := &Assets{homeTemplate: string(home), favicons: map[string]string{}, files: map[string]assetFile{}}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -59,6 +70,12 @@ func loadAssets(dir string) (*Assets, error) {
 			return nil, err
 		}
 		hashed := strings.HasPrefix(name, "main-")
+		if m := faviconRE.FindStringSubmatch(name); m != nil {
+			a.favicons[m[1]] = "/" + name
+			if m[2] != "" {
+				hashed = true
+			}
+		}
 		a.files["/"+name] = assetFile{contentType: ct, immutable: hashed, body: body}
 		switch {
 		case hashed && strings.HasSuffix(name, ".js"):
@@ -67,8 +84,10 @@ func loadAssets(dir string) (*Assets, error) {
 			a.mainCSS = "/" + name
 		}
 	}
-	if f, ok := a.files["/favicon-32.png"]; ok {
-		a.files["/favicon.ico"] = f
+	// Browsers auto-request /favicon.ico, so it keeps a fixed (revalidated) URL
+	// rather than a hashed one.
+	if f, ok := a.files[a.faviconPath("32")]; ok {
+		a.files["/favicon.ico"] = assetFile{contentType: "image/x-icon", body: f.body}
 	}
 	return a, nil
 }

--- a/server/config.go
+++ b/server/config.go
@@ -20,16 +20,18 @@ const (
 	proxySessionCount       = 10
 
 	defaultCacheTTLSeconds  = 3600
-	negativeCacheTTL        = 60 * time.Second
 	defaultProxyHourlyLimit = 180
 
-	fetchRaceCount     = 2
+	transientErrorCacheSecond = 300
+	permanentErrorCacheSecond = 3600
+
+	fetchRaceCount     = 3
 	fetchRaceExplorers = 1
 	ewmaAlpha          = 0.3
 	fetchTimeout       = 4500 * time.Millisecond
 
 	fetchHedgeDelay = 1500 * time.Millisecond
-	fetchHedgeCount = 1
+	fetchHedgeCount = 2
 
 	rotateCooldown  = 3 * time.Second
 	maxCacheEntries = 500
@@ -43,13 +45,15 @@ const (
 	homeBrowserCacheSecs = 60
 	iconCacheSeconds     = 86400
 
-	errorEmbedCacheSecond = 600
-
 	serviceName          = "oginstagram"
 	rateLimitTitle       = "Rate Limit Exceeded"
 	rateLimitDescription = "Instagram fetching is temporarily rate limited. Please try again later."
 
-	instagramAppUA = "Instagram 273.0.0.16.70 (iPhone15,2; iOS 17_5_1; en_US; en-US; scale=3.00; 1290x2796; 470085518)"
+	instagramAppUA  = "Instagram 273.0.0.16.70 (iPhone15,2; iOS 17_5_1; en_US; en-US; scale=3.00; 1290x2796; 470085518)"
+	instagramWebUA  = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.112 Safari/537.36"
+	instagramAsbdID = "129477"
+
+	profileCacheTTLSeconds = 1800
 
 	snowcodeChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789{}[]\":,.-_"
 )

--- a/server/errors.go
+++ b/server/errors.go
@@ -1,0 +1,56 @@
+package main
+
+const (
+	reasonConnection     = "ClientConnectionError"
+	reasonIncompleteRead = "ClientIncompleteReadError"
+	reasonJSONDecode     = "ClientJSONDecodeError"
+	reasonLoginRequired  = "ClientLoginRequired"
+	reasonUnauthorized   = "ClientUnauthorizedError"
+	reasonForbidden      = "ClientForbiddenError"
+	reasonThrottled      = "ClientThrottledError"
+	reasonClientError    = "ClientError"
+	reasonGraphql        = "ClientGraphqlError"
+	reasonBadRequest     = "ClientBadRequestError"
+	reasonNotFound       = "ClientNotFoundError"
+	reasonMediaNotFound  = "MediaNotFound"
+)
+
+// reasonInfo declares how we treat each classification:
+//   - rotateIP:  the proxy session/IP looks at fault → rotate + cooldown
+//   - transient: not a permanent fact → short cache, "Temporarily unavailable" card
+type reasonInfo struct {
+	rotateIP  bool
+	transient bool
+}
+
+var reasonRegistry = map[string]reasonInfo{
+	reasonConnection:     {rotateIP: true, transient: true},
+	reasonIncompleteRead: {rotateIP: true, transient: true},
+	reasonJSONDecode:     {rotateIP: true, transient: true},
+	reasonLoginRequired:  {rotateIP: true, transient: true},
+	reasonUnauthorized:   {rotateIP: true, transient: true},
+	reasonForbidden:      {rotateIP: true, transient: true},
+	reasonThrottled:      {rotateIP: true, transient: true},
+	reasonClientError:    {rotateIP: false, transient: true},
+	reasonGraphql:        {rotateIP: false, transient: true},
+	reasonBadRequest:     {rotateIP: false, transient: false},
+	reasonNotFound:       {rotateIP: false, transient: false},
+	reasonMediaNotFound:  {rotateIP: false, transient: false},
+}
+
+func reasonOf(reason string) reasonInfo {
+	if r, ok := reasonRegistry[reason]; ok {
+		return r
+	}
+	return reasonInfo{rotateIP: false, transient: true}
+}
+
+func shouldRotate(reason string) bool { return reasonOf(reason).rotateIP }
+func isTransient(reason string) bool  { return reasonOf(reason).transient }
+
+func errorCacheSeconds(reason string) int {
+	if isTransient(reason) {
+		return transientErrorCacheSecond
+	}
+	return permanentErrorCacheSecond
+}

--- a/server/fetch.go
+++ b/server/fetch.go
@@ -46,7 +46,7 @@ func (a *App) raceFetch(spec gqlSpec) (string, *AppError) {
 		if len(a.pool.sessions) == 0 {
 			return "", igErr(503, reasonConnection, "Instagram proxy sessions are not configured")
 		}
-		return "", igErr(503, reasonConnection, "all Instagram proxy sessions are rate limited or cooling down")
+		return "", ephemeralErr(503, reasonConnection, "all Instagram proxy sessions are rate limited or cooling down")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -96,7 +96,11 @@ func (a *App) raceFetch(spec gqlSpec) (string, *AppError) {
 			if r.err == nil {
 				return r.body, nil
 			}
-			if lastErr == nil {
+			// Prefer the most authoritative error: a permanent answer from
+			// Instagram (e.g. 404 not-found) beats a transient one (e.g. a
+			// rate-limited session's 401), so racing a busy IP can't mask a
+			// genuine "account doesn't exist".
+			if lastErr == nil || (isTransient(lastErr.Reason) && !isTransient(r.err.Reason)) {
 				lastErr = r.err
 			}
 			if pending == 0 && !hedged {
@@ -168,7 +172,7 @@ func (a *App) attemptFetch(ctx context.Context, spec gqlSpec, s *Session) (strin
 			reason = reasonNotFound
 		}
 
-		if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 429 || resp.StatusCode >= 500 {
+		if shouldRotate(reason) {
 			failOnce(reason)
 		}
 		return "", igErr(resp.StatusCode, reason, msg)
@@ -186,7 +190,9 @@ func (a *App) attemptFetch(ctx context.Context, spec gqlSpec, s *Session) (strin
 
 	parsed := gjson.Parse(bodyText)
 	if parsed.Get("status").String() == "fail" {
-		failOnce(reasonGraphql)
+		if shouldRotate(reasonGraphql) {
+			failOnce(reasonGraphql)
+		}
 		msg := strings.TrimSpace(parsed.Get("message").String())
 		if msg == "" {
 			msg = "Instagram request failed"
@@ -196,6 +202,30 @@ func (a *App) attemptFetch(ctx context.Context, spec gqlSpec, s *Session) (strin
 
 	a.pool.recordLatency(s, time.Since(started))
 	return bodyText, nil
+}
+
+func (a *App) proxyRawGet(rawURL string, headers map[string]string) (int, string, bool) {
+	sessions := a.pool.pick(1, nil)
+	if len(sessions) == 0 {
+		return 0, "", false
+	}
+	s := sessions[0]
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0, "", false
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := s.getClient().Do(req)
+	if err != nil {
+		return 0, "", false
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	return resp.StatusCode, string(raw), true
 }
 
 func instagramMessage(body string) string {

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -157,7 +157,7 @@ func optionalString(v string) string { return strings.TrimSpace(v) }
 
 const galleryEmoji = "🖼️"
 
-const activityMaxImages = 3
+const activityMaxImages = 4
 
 type attachmentSelection struct {
 	items     []selectedAttachment
@@ -193,10 +193,9 @@ func selectActivityAttachments(post Post, mediaIndex int, specified bool) attach
 			}
 		}
 	}
-	if len(images) == total {
-		return attachmentSelection{items: images, indicator: galleryEmoji + " " + strconv.Itoa(total)}
-	}
-	return attachmentSelection{items: images, indicator: galleryEmoji + " " + strconv.Itoa(len(images)) + " / " + strconv.Itoa(total)}
+	// A capped gallery shows fewer images than the post has, but the indicator is
+	// just the total count — an "X / Y" here would read like a specific-image pick.
+	return attachmentSelection{items: images, indicator: galleryEmoji + " " + strconv.Itoa(total)}
 }
 
 func singleAttachmentIndicator(post Post, selectedIndex int) string {

--- a/server/home.go
+++ b/server/home.go
@@ -138,8 +138,8 @@ func (a *App) buildHomeHTML(host, acceptLanguage string, forced *HomeLocale) str
 		`<link rel="canonical" href="` + attr(base+canonicalPath) + `">`,
 		`<meta name="theme-color" content="` + attr(a.cfg.BrandColor) + `">`,
 		`<meta property="og:url" content="` + attr(base+canonicalPath) + `">`,
-		`<meta property="og:image" content="` + attr(base+"/favicon-192.png") + `">`,
-		`<meta property="twitter:image" content="` + attr(base+"/favicon-192.png") + `">`,
+		`<meta property="og:image" content="` + attr(base+a.assets.faviconPath("192")) + `">`,
+		`<meta property="twitter:image" content="` + attr(base+a.assets.faviconPath("192")) + `">`,
 		`<link rel="alternate" hreflang="en" href="` + attr(base+"/en") + `">`,
 		`<link rel="alternate" hreflang="ja" href="` + attr(base+"/ja") + `">`,
 		`<link rel="alternate" hreflang="ko" href="` + attr(base+"/ko") + `">`,
@@ -154,6 +154,8 @@ func (a *App) buildHomeHTML(host, acceptLanguage string, forced *HomeLocale) str
 		"{{T_TAGLINE}}", htmlEscape(t.Tagline),
 		"{{MAIN_JS}}", a.assets.mainJS,
 		"{{MAIN_CSS}}", a.assets.mainCSS,
+		"{{FAVICON_192}}", a.assets.faviconPath("192"),
+		"{{FAVICON_32}}", a.assets.faviconPath("32"),
 	)
 	return repl.Replace(a.assets.homeTemplate)
 }

--- a/server/home.go
+++ b/server/home.go
@@ -34,7 +34,7 @@ type homeStrings struct {
 	SupportedH2  string
 	SupportNote  string
 	Posts        string
-	UserPosts    string
+	UserProfile  string
 	Reels        string
 	StatusH2     string
 	StatusSub    string
@@ -65,7 +65,7 @@ type homeAppData struct {
 	SupportedH2  string `json:"supportedH2"`
 	SupportNote  string `json:"supportNote"`
 	Posts        string `json:"posts"`
-	UserPosts    string `json:"userPosts"`
+	UserProfile  string `json:"userProfile"`
 	Reels        string `json:"reels"`
 	StatusH2     string `json:"statusH2"`
 	StatusSub    string `json:"statusSub"`
@@ -80,7 +80,7 @@ var homeStringsByLocale = map[HomeLocale]homeStrings{
 		Lang: "en", Tagline: "Instagram embed proxy for Discord, Telegram, and anything that supports Open Graph Protocol or ActivityPub — with rich previews: media, caption, and stats.",
 		SupportCta: "Support me on Ko-fi", DarkMode: "Use dark mode", LightMode: "Use light mode", UsageH2: "Usage", NormalView: "Normal View", NormalDesc: "Embeds the creator's profile, caption, stats, and media.",
 		GalleryView: "Gallery View", GalleryDesc: "Embeds the creator's profile and media.",
-		DirectView: "Direct View", DirectDesc: "Embeds only the direct media URL.", SupportedH2: "Supported URLs", Posts: "Posts", UserPosts: "User posts/reels", Reels: "Reels",
+		DirectView: "Direct View", DirectDesc: "Embeds only the direct media URL.", SupportedH2: "Supported URLs", Posts: "Posts", UserProfile: "User Profile", Reels: "Reels",
 		SupportNote: "Private posts, age-restricted posts, and posts unavailable in the United States are not supported.",
 		StatusH2:    "Status", StatusSub: "Last 24 hours", Requests: "Requests", ResponseTime: "Latency",
 		Disclaimer: "Instagram is a trademark of Meta Platforms, Inc. This service is not affiliated with, endorsed, or sponsored by Instagram or Meta.",
@@ -90,7 +90,7 @@ var homeStringsByLocale = map[HomeLocale]homeStrings{
 		Lang: "ja", Tagline: "Discord、Telegram、および Open Graph Protocol または ActivityPub に対応するあらゆるサービス向けの Instagram 埋め込みプロキシです。メディア、キャプション、統計情報を含むリッチプレビューを提供します。",
 		SupportCta: "Ko-fi で支援する", DarkMode: "ダークモードを使用", LightMode: "ライトモードを使用", UsageH2: "使い方", NormalView: "通常表示", NormalDesc: "作成者のプロフィール、キャプション、統計、メディアを埋め込みます。",
 		GalleryView: "ギャラリー表示", GalleryDesc: "作成者のプロフィールとメディアを埋め込みます。",
-		DirectView: "ダイレクト表示", DirectDesc: "メディアの直接 URL のみを埋め込みます。", SupportedH2: "対応 URL", Posts: "投稿", UserPosts: "ユーザーの投稿/リール", Reels: "リール",
+		DirectView: "ダイレクト表示", DirectDesc: "メディアの直接 URL のみを埋め込みます。", SupportedH2: "対応 URL", Posts: "投稿", UserProfile: "ユーザープロフィール", Reels: "リール",
 		SupportNote: "非公開投稿、年齢制限付きの投稿、および米国で利用できない投稿は対応していません。",
 		StatusH2:    "ステータス", StatusSub: "過去24時間", Requests: "リクエスト", ResponseTime: "レイテンシ",
 		Disclaimer: "Instagram は Meta Platforms, Inc. の商標です。本サービスは Instagram および Meta と提携・承認・後援関係にありません。",
@@ -100,7 +100,7 @@ var homeStringsByLocale = map[HomeLocale]homeStrings{
 		Lang: "ko", Tagline: "Discord, Telegram 및 Open Graph Protocol이나 ActivityPub를 지원하는 모든 서비스에서 사용할 수 있는 Instagram 임베드 프록시입니다. 미디어, 캡션, 통계가 포함된 리치 미리보기를 제공합니다.",
 		SupportCta: "Ko-fi에서 후원하기", DarkMode: "다크 모드 사용", LightMode: "라이트 모드 사용", UsageH2: "사용법", NormalView: "일반 보기", NormalDesc: "작성자 프로필, 캡션, 통계, 미디어를 모두 임베드합니다.",
 		GalleryView: "갤러리 보기", GalleryDesc: "작성자 프로필과 미디어를 임베드합니다.",
-		DirectView: "다이렉트 보기", DirectDesc: "미디어 직접 URL만 임베드합니다.", SupportedH2: "지원 URL", Posts: "게시물", UserPosts: "사용자 게시물/릴스", Reels: "릴스",
+		DirectView: "다이렉트 보기", DirectDesc: "미디어 직접 URL만 임베드합니다.", SupportedH2: "지원 URL", Posts: "게시물", UserProfile: "사용자 프로필", Reels: "릴스",
 		SupportNote: "비공개 게시물, 연령 제한 게시물, 미국에서 이용할 수 없는 게시물은 지원되지 않습니다.",
 		StatusH2:    "상태", StatusSub: "최근 24시간", Requests: "요청", ResponseTime: "지연 시간",
 		Disclaimer: "Instagram은 Meta Platforms, Inc.의 상표입니다. 본 서비스는 Instagram 또는 Meta와 제휴, 보증, 후원 관계가 없습니다.",
@@ -124,7 +124,7 @@ func (a *App) buildHomeHTML(host, acceptLanguage string, forced *HomeLocale) str
 		NormalView: t.NormalView, NormalDesc: t.NormalDesc, GalleryView: t.GalleryView,
 		GalleryDesc: t.GalleryDesc, DirectView: t.DirectView, DirectDesc: t.DirectDesc,
 		SupportedH2: t.SupportedH2, SupportNote: t.SupportNote, Posts: t.Posts,
-		UserPosts: t.UserPosts, Reels: t.Reels, StatusH2: t.StatusH2,
+		UserProfile: t.UserProfile, Reels: t.Reels, StatusH2: t.StatusH2,
 		StatusSub: t.StatusSub, Requests: t.Requests, ResponseTime: t.ResponseTime,
 		Disclaimer: t.Disclaimer, JS: t.JS,
 	})

--- a/server/main.go
+++ b/server/main.go
@@ -129,7 +129,7 @@ func (a *App) route(req *http.Request) resp {
 		return a.handleActivity(req, segments[3], false)
 	}
 	if len(segments) == 2 && segments[0] == "users" {
-		return cacheable(jsonResp(200, a.buildActivityAccount(segments[1])), edgeCacheSeconds)
+		return a.handleUserAccount(req, segments[1])
 	}
 	if route := parseEmbedSegments(segments); route != nil {
 		pathIndex := -1
@@ -138,7 +138,52 @@ func (a *App) route(req *http.Request) resp {
 		}
 		return a.handleEmbed(req, route.PostType, route.Shortcode, pathIndex)
 	}
+	if len(segments) == 1 && validUsername(segments[0]) {
+		return a.handleProfile(req, segments[0])
+	}
 	return resp{status: 404, headers: map[string]string{}}
+}
+
+func (a *App) handleProfile(req *http.Request, username string) resp {
+	origin := profileURL(username)
+	if !botRE.MatchString(req.Header.Get("User-Agent")) {
+		return redirectResp(origin, 307)
+	}
+	q := parseRequestQuery(req.URL.Query())
+	baseURL := a.publicBaseURL(req)
+	meta := &fetchMeta{}
+	p, err := a.getProfile(username, meta)
+	if err != nil {
+		title, desc := profileErrorCard(err.Reason)
+		embed := a.buildStatusEmbedHTML(baseURL, origin, title, desc)
+		r := htmlResp(200, embed)
+		r.headers["x-og-status"] = strconv.Itoa(err.Status)
+		if err.Reason != "" {
+			r.headers["x-og-reason"] = err.Reason
+		}
+		r = cacheable(r, errorCacheSeconds(err.Reason))
+		return tagFetch(r, meta)
+	}
+	return tagFetch(cacheable(htmlResp(200, a.buildProfileEmbedHTML(baseURL, req.Header.Get("User-Agent"), p, q.Gallery)), edgeCacheSeconds), meta)
+}
+
+func (a *App) handleUserAccount(req *http.Request, username string) resp {
+	p, err := a.getProfile(username, nil)
+	if err != nil {
+		return cacheable(jsonResp(200, a.buildFallbackAccount(username)), errorCacheSeconds(err.Reason))
+	}
+	return cacheable(jsonResp(200, a.buildProfileAccount(p)), edgeCacheSeconds)
+}
+
+func (a *App) handleProfileStatus(req *http.Request, statusID, username string) resp {
+	p, err := a.getProfile(username, nil)
+	if err != nil {
+		if isTransient(err.Reason) {
+			return jsonResp(err.Status, a.buildRateLimitActivityStatus(username))
+		}
+		return textResp(err.Status, err.Message)
+	}
+	return cacheable(jsonResp(200, a.buildProfileStatus(statusID, p)), edgeCacheSeconds)
 }
 
 func (a *App) handleEmbed(req *http.Request, postType, shortcode string, pathIndex int) resp {
@@ -156,9 +201,11 @@ func (a *App) handleEmbed(req *http.Request, postType, shortcode string, pathInd
 	post, err := a.getPost(shortcode, meta)
 	if err != nil {
 		reason := err.Reason
-		title, desc := errorCard(reason)
+		title, desc := postErrorCard(reason)
 
-		if reason == reasonMediaNotFound || reason == reasonNotFound {
+		// Only MediaNotFound (200 + null media) can carry a specific reason via
+		// oembed; a genuine HTTP 404 and everything else cannot be refined.
+		if reason == reasonMediaNotFound {
 			if r2, t2, d2, ok := a.oembedRefine(shortcode); ok {
 				reason, title, desc = r2, t2, d2
 			}
@@ -169,9 +216,7 @@ func (a *App) handleEmbed(req *http.Request, postType, shortcode string, pathInd
 		if reason != "" {
 			r.headers["x-og-reason"] = reason
 		}
-		if !isTransientStatus(err.Status) {
-			r = cacheable(r, errorEmbedCacheSecond)
-		}
+		r = cacheable(r, errorCacheSeconds(err.Reason))
 		return tagFetch(r, meta)
 	}
 	html := a.buildEmbedHTML(baseURL, req.Header.Get("User-Agent"), post, postType, mediaIndex, specified, q.Gallery)
@@ -190,7 +235,7 @@ func (a *App) handleOffload(req *http.Request, segments []string) resp {
 	meta := &fetchMeta{}
 	post, err := a.getPost(shortcode, meta)
 	if err != nil {
-		if isTransientStatus(err.Status) {
+		if isTransient(err.Reason) {
 			return tagFetch(redirectResp(instagramOrigin+"/p/"+pathEscape(shortcode)+"/", 302), meta)
 		}
 		return resp{status: err.Status, headers: map[string]string{"Content-Type": "text/plain; charset=utf-8"}, body: []byte(err.Message)}
@@ -208,6 +253,9 @@ func (a *App) handleOffload(req *http.Request, segments []string) resp {
 func (a *App) handleActivity(req *http.Request, statusID string, gallery bool) resp {
 	q := parseRequestQuery(req.URL.Query())
 	route := parseActivityCode(statusID)
+	if route.Username != "" {
+		return a.handleProfileStatus(req, statusID, route.Username)
+	}
 	gallery = gallery || q.Gallery || route.Gallery
 	if q.Shortcode != "" {
 		route.Shortcode = q.Shortcode
@@ -221,7 +269,7 @@ func (a *App) handleActivity(req *http.Request, statusID string, gallery bool) r
 	}
 	post, err := a.getPost(route.Shortcode, nil)
 	if err != nil {
-		if isTransientStatus(err.Status) {
+		if isTransient(err.Reason) {
 			return jsonResp(err.Status, a.buildRateLimitActivityStatus(route.Shortcode))
 		}
 		return textResp(err.Status, err.Message)
@@ -242,7 +290,7 @@ func (a *App) handleOEmbed(req *http.Request) resp {
 	baseURL := a.publicBaseURL(req)
 	post, err := a.getPost(q.Shortcode, nil)
 	if err != nil {
-		if isTransientStatus(err.Status) {
+		if isTransient(err.Reason) {
 			return jsonResp(err.Status, a.buildRateLimitOEmbed(baseURL, postType, q.Shortcode, mediaIndex, specified))
 		}
 		return textResp(err.Status, err.Message)

--- a/server/oembed.go
+++ b/server/oembed.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"context"
-	"io"
-	"net/http"
 	"net/url"
 
 	"github.com/tidwall/gjson"
@@ -16,25 +13,12 @@ func (c Config) oembedURL(shortcode string) string {
 }
 
 func (a *App) oembedRefine(shortcode string) (reason, title, desc string, override bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.cfg.oembedURL(shortcode), nil)
-	if err != nil {
-		return "", "", "", false
-	}
-	req.Header.Set("User-Agent", instagramAppUA)
-	req.Header.Set("Accept", "*/*")
-	req.Header.Set("X-IG-App-ID", instagramAppID)
-
-	resp, err := a.direct.Do(req)
-	if err != nil {
-		return "", "", "", false
-	}
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
-	resp.Body.Close()
-	body := string(raw)
-
-	if resp.StatusCode == 404 || !gjson.Valid(body) {
+	status, body, ok := a.proxyRawGet(a.cfg.oembedURL(shortcode), map[string]string{
+		"User-Agent":  instagramAppUA,
+		"Accept":      "*/*",
+		"X-IG-App-ID": instagramAppID,
+	})
+	if !ok || status == 404 || !gjson.Valid(body) {
 		return "", "", "", false
 	}
 	if gjson.Get(body, "status").String() == "fail" {

--- a/server/profile.go
+++ b/server/profile.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+type Profile struct {
+	Username       string
+	FullName       string
+	Biography      string
+	ProfilePic     string
+	FollowerCount  int
+	FollowingCount int
+	MediaCount     int
+	IsPrivate      bool
+	Recent         []string
+}
+
+var usernameRE = regexp.MustCompile(`^[A-Za-z0-9._]{1,30}$`)
+
+func validUsername(s string) bool { return usernameRE.MatchString(s) }
+
+func webProfileSpec(username string) gqlSpec {
+	return gqlSpec{
+		method: http.MethodGet,
+		url:    instagramOrigin + "/api/v1/users/web_profile_info/?username=" + url.QueryEscape(username),
+		headers: map[string]string{
+			"User-Agent":                  instagramWebUA,
+			"Accept":                      "*/*",
+			"Accept-Language":             "en-US,en;q=0.9",
+			"X-IG-App-ID":                 instagramAppID,
+			"X-Asbd-Id":                   instagramAsbdID,
+			"X-Requested-With":            "XMLHttpRequest",
+			"Sec-Ch-Prefers-Color-Scheme": "dark",
+			"Sec-Ch-Ua-Platform":          `"Linux"`,
+			"Sec-Ch-Ua-Mobile":            "?0",
+			"Sec-Fetch-Site":              "same-origin",
+			"Sec-Fetch-Mode":              "cors",
+			"Sec-Fetch-Dest":              "empty",
+			"Referer":                     instagramOrigin + "/",
+		},
+	}
+}
+
+func (a *App) fetchProfile(username string) (Profile, *AppError) {
+	body, err := a.raceFetch(webProfileSpec(username))
+	if err != nil {
+		return Profile{}, err
+	}
+	return parseProfile(body)
+}
+
+func parseProfile(body string) (Profile, *AppError) {
+	u := gjson.Get(body, "data.user")
+	if !present(u) {
+		return Profile{}, igErr(404, reasonNotFound, "user not found")
+	}
+	p := Profile{
+		Username:       u.Get("username").String(),
+		FullName:       u.Get("full_name").String(),
+		Biography:      u.Get("biography").String(),
+		ProfilePic:     normalizeCDNHost(firstNonEmpty(u.Get("profile_pic_url_hd").String(), u.Get("profile_pic_url").String())),
+		FollowerCount:  uintOf(u, "edge_followed_by.count"),
+		FollowingCount: uintOf(u, "edge_follow.count"),
+		MediaCount:     uintOf(u, "edge_owner_to_timeline_media.count"),
+		IsPrivate:      u.Get("is_private").Bool(),
+	}
+	if p.Username == "" {
+		return Profile{}, igErr(404, reasonMediaNotFound, "profile had no username")
+	}
+	for _, e := range u.Get("edge_owner_to_timeline_media.edges").Array() {
+		img := bestProfileImage(e.Get("node"))
+		if img == "" {
+			continue
+		}
+		p.Recent = append(p.Recent, normalizeCDNHost(img))
+		if len(p.Recent) >= profileGalleryMax {
+			break
+		}
+	}
+	return p, nil
+}
+
+func bestProfileImage(node gjson.Result) string {
+	if u := bestCandidateURL(node.Get("thumbnail_resources")); u != "" {
+		return u
+	}
+	for _, k := range []string{"thumbnail_src", "display_url"} {
+		if u := node.Get(k).String(); u != "" {
+			return u
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+type profileEntry struct {
+	profile   Profile
+	err       *AppError
+	expiresAt time.Time
+}
+
+type profileCall struct {
+	done  chan struct{}
+	entry *profileEntry
+	err   *AppError
+}
+
+func (a *App) getProfile(username string, meta *fetchMeta) (Profile, *AppError) {
+	if !validUsername(username) {
+		return Profile{}, igErr(404, reasonNotFound, "invalid username")
+	}
+
+	a.profileMu.Lock()
+	if e, ok := a.profiles[username]; ok && e.expiresAt.After(time.Now()) {
+		a.profileMu.Unlock()
+		return e.profile, e.err
+	}
+	a.profileMu.Unlock()
+
+	a.profileFlightMu.Lock()
+	if call, ok := a.profileFlight[username]; ok {
+		a.profileFlightMu.Unlock()
+		<-call.done
+		if call.entry != nil {
+			return call.entry.profile, call.err
+		}
+		return Profile{}, call.err
+	}
+	call := &profileCall{done: make(chan struct{})}
+	a.profileFlight[username] = call
+	a.profileFlightMu.Unlock()
+
+	if meta != nil {
+		meta.fetched = true
+	}
+
+	profile, err := a.fetchProfile(username)
+	if err == nil || !err.Ephemeral {
+		ttl := profileCacheTTLSeconds
+		if err != nil {
+			ttl = errorCacheSeconds(err.Reason)
+		}
+		entry := &profileEntry{profile: profile, err: err, expiresAt: time.Now().Add(time.Duration(ttl) * time.Second)}
+		a.storeProfile(username, entry)
+		call.entry, call.err = entry, err
+	} else {
+		call.err = err
+	}
+
+	a.profileFlightMu.Lock()
+	delete(a.profileFlight, username)
+	a.profileFlightMu.Unlock()
+	close(call.done)
+	return profile, err
+}
+
+func (a *App) storeProfile(username string, entry *profileEntry) {
+	a.profileMu.Lock()
+	defer a.profileMu.Unlock()
+	if _, exists := a.profiles[username]; !exists {
+		a.profileOrder = append(a.profileOrder, username)
+	}
+	a.profiles[username] = entry
+	for len(a.profiles) > maxCacheEntries && len(a.profileOrder) > 0 {
+		oldest := a.profileOrder[0]
+		a.profileOrder = a.profileOrder[1:]
+		delete(a.profiles, oldest)
+	}
+}

--- a/server/render.go
+++ b/server/render.go
@@ -12,13 +12,12 @@ func isTelegramBot(ua string) bool { return strings.Contains(strings.ToLower(ua)
 func isDiscordBot(ua string) bool  { return strings.Contains(strings.ToLower(ua), "discordbot") }
 
 func (a *App) faviconLinks(baseURL string) []string {
-	return []string{
-		`<link href="` + baseURL + `/favicon-64.png" rel="icon" sizes="64x64" type="image/png">`,
-		`<link href="` + baseURL + `/favicon-48.png" rel="icon" sizes="48x48" type="image/png">`,
-		`<link href="` + baseURL + `/favicon-32.png" rel="icon" sizes="32x32" type="image/png">`,
-		`<link href="` + baseURL + `/favicon-24.png" rel="icon" sizes="24x24" type="image/png">`,
-		`<link href="` + baseURL + `/favicon-16.png" rel="icon" sizes="16x16" type="image/png">`,
+	sizes := []string{"64", "48", "32", "24", "16"}
+	links := make([]string, 0, len(sizes))
+	for _, s := range sizes {
+		links = append(links, `<link href="`+baseURL+a.assets.faviconPath(s)+`" rel="icon" sizes="`+s+`x`+s+`" type="image/png">`)
 	}
+	return links
 }
 
 func (a *App) buildEmbedHTML(baseURL, ua string, post Post, postType string, mediaIndex int, specified, gallery bool) string {

--- a/server/render.go
+++ b/server/render.go
@@ -139,27 +139,11 @@ A lightweight Open Graph and ActivityPub bridge for Instagram links.
 --><head>` + strings.Join(h, "") + `</head><body></body></html>`)
 }
 
-func errorCard(reason string) (title, desc string) {
-	switch reason {
-	case reasonLoginRequired:
-		return "Login required", "Instagram requires logging in to view this content."
-	case reasonThrottled:
-		return "Rate limited", "Instagram is rate limiting requests right now. Please try again shortly."
-	case reasonNotFound, reasonMediaNotFound:
-		return "Post unavailable", "This post isn't available - it may be deleted, set to private, or the link is incorrect."
-	case reasonForbidden:
-		return "Unavailable", "Instagram blocked this request (forbidden)."
-	case reasonUnauthorized:
-		return "Unavailable", "Instagram returned unauthorized for this request."
-	case reasonBadRequest:
-		return "Unavailable", "Instagram rejected this request."
-	case reasonConnection:
-		return "Unavailable", "Couldn't reach Instagram right now. Please try again."
-	case reasonJSONDecode, reasonGraphql:
-		return "Unavailable", "Instagram returned an unexpected response."
-	default:
-		return "Unavailable", "Couldn't load this post right now. Please try again."
+func postErrorCard(reason string) (title, desc string) {
+	if isTransient(reason) {
+		return "Temporarily unavailable", "Couldn't load this post right now. Please try again in a moment."
 	}
+	return "Post unavailable", "This post isn't available - it may be deleted, set to private, or the link is incorrect."
 }
 
 func (a *App) buildStatusEmbedHTML(baseURL, originURL, title, description string) string {
@@ -261,7 +245,7 @@ func (a *App) buildActivityStatus(baseURL, statusID string, post Post, postType 
 	if gallery {
 		content = ""
 	}
-	profileURL := instagramOrigin + "/" + post.Username + "/"
+	authorURL := profileURL(post.Username)
 
 	media := make([]any, 0, len(selection.items))
 	for _, it := range selection.items {
@@ -283,7 +267,7 @@ func (a *App) buildActivityStatus(baseURL, statusID string, post Post, postType 
 		"visibility":             "public",
 		"application":            map[string]any{"name": "Instagram", "website": nil},
 		"media_attachments":      media,
-		"account":                activityAccount(post, profileURL),
+		"account":                activityAccount(post, authorURL),
 		"mentions":               []any{},
 		"tags":                   []any{},
 		"emojis":                 []any{},
@@ -292,7 +276,7 @@ func (a *App) buildActivityStatus(baseURL, statusID string, post Post, postType 
 	})
 }
 
-func activityAccount(post Post, profileURL string) map[string]any {
+func activityAccount(post Post, authorURL string) map[string]any {
 	var avatar any
 	if s := optionalString(post.ProfilePic); s != "" {
 		avatar = s
@@ -302,8 +286,8 @@ func activityAccount(post Post, profileURL string) map[string]any {
 		"display_name":     post.FullName,
 		"username":         post.Username,
 		"acct":             post.Username,
-		"url":              profileURL,
-		"uri":              profileURL,
+		"url":              authorURL,
+		"uri":              authorURL,
 		"created_at":       isoTime(post.CreatedAt),
 		"locked":           false,
 		"bot":              false,
@@ -323,19 +307,19 @@ func activityAccount(post Post, profileURL string) map[string]any {
 	}
 }
 
-func (a *App) buildActivityAccount(username string) []byte {
+func (a *App) buildFallbackAccount(username string) []byte {
 	safe := strings.TrimSpace(username)
 	if safe == "" {
 		safe = a.cfg.BrandName
 	}
-	profileURL := instagramOrigin + "/" + pathEscape(safe) + "/"
+	accountURL := profileURL(safe)
 	return jsonBytes(map[string]any{
 		"id":               safe,
 		"display_name":     safe,
 		"username":         safe,
 		"acct":             safe,
-		"url":              profileURL,
-		"uri":              profileURL,
+		"url":              accountURL,
+		"uri":              accountURL,
 		"created_at":       isoTime(epochUTC()),
 		"locked":           false,
 		"bot":              false,
@@ -357,9 +341,8 @@ func (a *App) buildActivityAccount(username string) []byte {
 	})
 }
 
-func (a *App) buildRateLimitActivityStatus(shortcode string) []byte {
+func (a *App) buildRateLimitActivityStatus(id string) []byte {
 	now := isoTime(nowUTC())
-	id := shortcode
 	if id == "" {
 		id = "rate-limit"
 	}

--- a/server/render_profile.go
+++ b/server/render_profile.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+func profileURL(username string) string {
+	return instagramOrigin + "/" + pathEscape(username) + "/"
+}
+
+func profileDisplayName(p Profile) string {
+	if p.FullName != "" {
+		return p.FullName
+	}
+	return p.Username
+}
+
+const profilePrivateNotice = "🔒 This profile is private."
+
+func profileStatsLine(p Profile) string {
+	return "📝 " + fmtCount(p.MediaCount) + " 👤 " + fmtCount(p.FollowerCount)
+}
+
+const profileGalleryMax = 4
+
+func profileMediaURLs(p Profile) []string {
+	if p.IsPrivate {
+		return nil
+	}
+	return p.Recent
+}
+
+func profileBioHTML(p Profile) string {
+	bio := normalizeCaption(p.Biography)
+	if bio == "" {
+		return ""
+	}
+	return "<p>" + strings.ReplaceAll(htmlEscape(bio), "\n", "<br>") + "</p>"
+}
+
+func profileErrorCard(reason string) (title, desc string) {
+	if isTransient(reason) {
+		return "Temporarily unavailable", "Couldn't load this profile right now. Please try again in a moment."
+	}
+	return "Account unavailable", "This account isn't available - it may not exist, be deactivated, or the username is incorrect."
+}
+
+func (a *App) buildProfileEmbedHTML(baseURL, ua string, p Profile, gallery bool) string {
+	origin := profileURL(p.Username)
+	title := profileDisplayName(p) + " (@" + p.Username + ")"
+
+	description := ""
+	if !gallery {
+		description = profileStatsLine(p)
+		if bio := normalizeCaption(p.Biography); bio != "" {
+			description += "\n\n" + bio
+		}
+		if p.IsPrivate {
+			description += "\n\n" + profilePrivateNotice
+		}
+	}
+
+	image := p.ProfilePic
+
+	h := []string{
+		`<meta charset="utf-8">`,
+		`<link rel="canonical" href="` + attr(origin) + `">`,
+		`<meta property="og:url" content="` + attr(origin) + `">`,
+		`<meta property="og:type" content="profile">`,
+		`<meta property="profile:username" content="` + attr(p.Username) + `">`,
+		`<meta property="og:site_name" content="` + attr(a.cfg.BrandName) + `">`,
+		`<meta property="og:title" content="` + attr(title) + `">`,
+		`<meta property="twitter:title" content="` + attr(title) + `">`,
+		`<meta property="twitter:site" content="@` + attr(p.Username) + `">`,
+		`<meta property="twitter:creator" content="@` + attr(p.Username) + `">`,
+		`<meta property="theme-color" content="` + attr(a.cfg.BrandColor) + `">`,
+		`<meta property="twitter:card" content="summary">`,
+		`<meta property="og:image" content="` + attr(image) + `">`,
+		`<meta property="twitter:image" content="` + attr(image) + `">`,
+	}
+	if description != "" {
+		h = append(h,
+			`<meta name="description" content="`+attr(description)+`">`,
+			`<meta property="og:description" content="`+attr(description)+`">`,
+			`<meta property="twitter:description" content="`+attr(description)+`">`,
+		)
+	}
+	h = append(h, a.faviconLinks(baseURL)...)
+	if isDiscordBot(ua) {
+		activityHref := baseURL + "/users/" + pathEscape(p.Username) + "/statuses/" + pathEscape(profileActivityCode(p.Username))
+		h = append(h, `<link href="`+attr(activityHref)+`" rel="alternate" type="application/activity+json">`)
+	}
+
+	return compactHTML(`<!DOCTYPE html><html lang="en"><head>` + strings.Join(h, "") + `</head><body></body></html>`)
+}
+
+func profileAccountMap(p Profile) map[string]any {
+	url := profileURL(p.Username)
+	var avatar any
+	if p.ProfilePic != "" {
+		avatar = p.ProfilePic
+	}
+	var header any
+	if thumbs := profileMediaURLs(p); len(thumbs) > 0 {
+		header = thumbs[0]
+	}
+	return map[string]any{
+		"id":              p.Username,
+		"username":        p.Username,
+		"acct":            p.Username,
+		"display_name":    profileDisplayName(p),
+		"note":            profileBioHTML(p),
+		"url":             url,
+		"uri":             url,
+		"avatar":          avatar,
+		"avatar_static":   avatar,
+		"header":          header,
+		"header_static":   header,
+		"followers_count": p.FollowerCount,
+		"following_count": p.FollowingCount,
+		"statuses_count":  p.MediaCount,
+		"locked":          p.IsPrivate,
+		"bot":             false,
+		"discoverable":    true,
+		"group":           false,
+		"created_at":      isoTime(epochUTC()),
+		"last_status_at":  nil,
+		"emojis":          []any{},
+		"fields":          []any{},
+	}
+}
+
+func (a *App) buildProfileAccount(p Profile) []byte {
+	return jsonBytes(profileAccountMap(p))
+}
+
+func (a *App) buildProfileStatus(statusID string, p Profile) []byte {
+	url := profileURL(p.Username)
+	content := "<p><b>" + htmlEscape(profileStatsLine(p)) + "</b></p>" + profileBioHTML(p)
+	if p.IsPrivate {
+		content += "<p>" + htmlEscape(profilePrivateNotice) + "</p>"
+	}
+
+	thumbs := profileMediaURLs(p)
+	media := make([]any, 0, len(thumbs))
+	for i, t := range thumbs {
+		media = append(media, map[string]any{
+			"id":          strconv.Itoa(i + 1),
+			"type":        "image",
+			"url":         t,
+			"preview_url": t,
+			"remote_url":  nil,
+			"description": nil,
+			"meta":        map[string]any{"original": map[string]any{"aspect": 1.0}},
+		})
+	}
+
+	return jsonBytes(map[string]any{
+		"id":                     statusID,
+		"url":                    url,
+		"uri":                    url,
+		"created_at":             nil,
+		"edited_at":              nil,
+		"content":                content,
+		"spoiler_text":           "",
+		"visibility":             "public",
+		"language":               "en",
+		"in_reply_to_id":         nil,
+		"in_reply_to_account_id": nil,
+		"reblog":                 nil,
+		"media_attachments":      media,
+		"account":                profileAccountMap(p),
+		"application":            map[string]any{"name": "Instagram", "website": nil},
+		"mentions":               []any{},
+		"tags":                   []any{},
+		"emojis":                 []any{},
+		"card":                   nil,
+		"poll":                   nil,
+	})
+}

--- a/server/snowcode.go
+++ b/server/snowcode.go
@@ -28,8 +28,18 @@ func activityCodeFor(postType, shortcode string, mediaIndex int, specified, gall
 	return shortcode
 }
 
+func profileActivityCode(username string) string {
+	if encoded, ok := encodeSnowcodePayload(`"u":"` + username + `"`); ok {
+		return encoded
+	}
+	return username
+}
+
 func parseActivityCode(code string) ActivityRoute {
 	if data, ok := decodeSnowcode(code); ok {
+		if u, isStr := data["u"].(string); isStr && u != "" {
+			return ActivityRoute{Username: u}
+		}
 		if i, isStr := data["i"].(string); isStr && i != "" {
 			route := ActivityRoute{Shortcode: i, PostType: "p"}
 			if p, isStr := data["p"].(string); isStr {

--- a/server/types.go
+++ b/server/types.go
@@ -55,6 +55,7 @@ type RequestQuery struct {
 }
 
 type ActivityRoute struct {
+	Username            string
 	Shortcode           string
 	PostType            string
 	MediaIndex          int
@@ -66,6 +67,10 @@ type AppError struct {
 	Status  int
 	Message string
 	Reason  string
+	// Ephemeral marks a purely local, momentary condition (e.g. the proxy pool
+	// is exhausted/cooling down) that never reached Instagram, so callers must
+	// not cache it — the next request may succeed immediately.
+	Ephemeral bool
 }
 
 func (e *AppError) Error() string { return e.Message }
@@ -78,20 +83,6 @@ func igErr(status int, reason, message string) *AppError {
 	return &AppError{Status: status, Message: message, Reason: reason}
 }
 
-const (
-	reasonLoginRequired = "ClientLoginRequired"
-	reasonUnauthorized  = "ClientUnauthorizedError"
-	reasonForbidden     = "ClientForbiddenError"
-	reasonBadRequest    = "ClientBadRequestError"
-	reasonThrottled     = "ClientThrottledError"
-	reasonNotFound      = "ClientNotFoundError"
-	reasonMediaNotFound = "MediaNotFound"
-	reasonGraphql       = "ClientGraphqlError"
-	reasonJSONDecode    = "ClientJSONDecodeError"
-	reasonConnection    = "ClientConnectionError"
-	reasonClientError   = "ClientError"
-)
-
-func isTransientStatus(status int) bool {
-	return status == 401 || status == 403 || status == 429 || status >= 500
+func ephemeralErr(status int, reason, message string) *AppError {
+	return &AppError{Status: status, Message: message, Reason: reason, Ephemeral: true}
 }

--- a/shared/routes.ts
+++ b/shared/routes.ts
@@ -13,6 +13,12 @@ function validShortcode(value: string): boolean {
   return shortcodeRE.test(value);
 }
 
+const usernameRE = /^[A-Za-z0-9._]{1,30}$/;
+
+export function validUsername(value: string): boolean {
+  return usernameRE.test(value);
+}
+
 export function parseEmbedSegments(segments: string[]): EmbedRoute | null {
   if ((segments.length === 2 || segments.length === 3) && isPostRouteType(segments[0]) && validShortcode(segments[1])) {
     const pathIndex = optionalPathIndex(segments, 2);

--- a/web/hash-favicons.mjs
+++ b/web/hash-favicons.mjs
@@ -1,0 +1,13 @@
+import { readdirSync, readFileSync, renameSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const dir = fileURLToPath(new URL("./dist/", import.meta.url));
+for (const name of readdirSync(dir)) {
+  const m = /^favicon-(\d+)\.png$/.exec(name);
+  if (!m) continue;
+  const hash = createHash("sha256").update(readFileSync(dir + name)).digest("hex").slice(0, 8);
+  const next = `favicon-${m[1]}-${hash}.png`;
+  renameSync(dir + name, dir + next);
+  console.log(`favicon: ${name} -> ${next}`);
+}

--- a/web/index.html
+++ b/web/index.html
@@ -13,8 +13,8 @@
   <meta property="twitter:title" content="{{BRAND}}">
   <meta property="twitter:description" content="{{T_TAGLINE}}">
   {{HEAD_LINKS}}
-  <link rel="icon" href="/favicon-192.png" sizes="192x192" type="image/png">
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png">
+  <link rel="icon" href="{{FAVICON_192}}" sizes="192x192" type="image/png">
+  <link rel="icon" href="{{FAVICON_32}}" sizes="32x32" type="image/png">
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="stylesheet" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp-dynamic-subset.min.css">
   <link rel="stylesheet" href="{{MAIN_CSS}}">

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -39,7 +39,7 @@ type AppData = {
   supportURL: string; supportCta: string; githubURL: string; darkMode: string; lightMode: string;
   usageH2: string; normalView: string; normalDesc: string; galleryView: string;
   galleryDesc: string; directView: string; directDesc: string; supportedH2: string;
-  supportNote: string; posts: string; userPosts: string; reels: string;
+  supportNote: string; posts: string; userProfile: string; reels: string;
   statusH2: string; statusSub: string; requests: string; responseTime: string;
   disclaimer: string; js: Copy;
 };
@@ -86,8 +86,8 @@ function UsageCard({ title, url, description }: { title: string; url: React.Reac
     <LayerCard.Secondary>{title}</LayerCard.Secondary>
     <LayerCard.Primary>
       <div className="flex flex-col gap-3">
-        <div className="break-words"><Text variant="secondary" size="sm">{url}</Text></div>
-        <Text variant="secondary">{description}</Text>
+        <div className="break-words"><Text variant="body" size="base">{url}</Text></div>
+        <Text variant="secondary" size="base">{description}</Text>
       </div>
     </LayerCard.Primary>
   </LayerCard>;
@@ -137,7 +137,7 @@ function App() {
           <div className="flex items-center gap-2">
           <Select
             aria-label={data.js.language}
-            size="sm"
+            size="base"
             className="w-32"
             container={overlayPortal}
             value={data.lang}
@@ -145,7 +145,7 @@ function App() {
             onValueChange={(value) => { if (value) location.href = `/${value}`; }}
           />
           <Tooltip container={overlayPortal} content={dark ? data.lightMode : data.darkMode} side="bottom" render={
-            <Button shape="square" size="sm" variant="ghost" aria-label={dark ? data.lightMode : data.darkMode}
+            <Button shape="square" size="base" variant="ghost" aria-label={dark ? data.lightMode : data.darkMode}
               icon={dark ? Sun : Moon} onClick={() => setTheme(!dark)} />
           } />
           </div>
@@ -167,18 +167,18 @@ function App() {
         <section className="page-section" aria-labelledby="usage-title">
           <Text id="usage-title" variant="heading2" as="h2">{data.usageH2}</Text>
           <Grid className="usage-grid" variant="3up" gap="sm">
-            <UsageCard title={data.normalView} url={<>https://<HighlightedHost host={data.host} />/p/…/</>} description={data.normalDesc} />
-            <UsageCard title={data.galleryView} url={<>https://<strong className="key-prefix">g.</strong><HighlightedHost host={data.host} />/p/…/</>} description={data.galleryDesc} />
-            <UsageCard title={data.directView} url={<>https://<strong className="key-prefix">d.</strong><HighlightedHost host={data.host} />/p/…/</>} description={data.directDesc} />
+            <UsageCard title={data.normalView} url={<><span className="text-kumo-subtle">https://</span><HighlightedHost host={data.host} /></>} description={data.normalDesc} />
+            <UsageCard title={data.galleryView} url={<><span className="text-kumo-subtle">https://</span><strong className="key-prefix">g.</strong><HighlightedHost host={data.host} /></>} description={data.galleryDesc} />
+            <UsageCard title={data.directView} url={<><span className="text-kumo-subtle">https://</span><strong className="key-prefix">d.</strong><HighlightedHost host={data.host} /></>} description={data.directDesc} />
           </Grid>
         </section>
 
         <section className="page-section" aria-labelledby="supported-title">
           <Text id="supported-title" variant="heading2" as="h2">{data.supportedH2}</Text>
-          <Grid variant="3up" gap="sm">
-            <LayerCard><LayerCard.Secondary>{data.posts}</LayerCard.Secondary><LayerCard.Primary><Text variant="secondary" size="sm">instagram.com/<strong>p</strong>/…</Text></LayerCard.Primary></LayerCard>
-            <LayerCard><LayerCard.Secondary>{data.reels}</LayerCard.Secondary><LayerCard.Primary><Text variant="secondary" size="sm">instagram.com/<strong>reel</strong>(s)/…</Text></LayerCard.Primary></LayerCard>
-            <LayerCard><LayerCard.Secondary>{data.userPosts}</LayerCard.Secondary><LayerCard.Primary><Text variant="secondary" size="sm">instagram.com/<strong>username</strong>/…</Text></LayerCard.Primary></LayerCard>
+          <Grid variant="3up" gap="sm" className="supported-grid">
+            <LayerCard><LayerCard.Secondary>{data.posts}</LayerCard.Secondary><LayerCard.Primary><Text variant="secondary" size="base">instagram.com/<strong className="text-kumo-default">p</strong>/…</Text><Text variant="secondary" size="base">instagram.com/username/<strong className="text-kumo-default">p</strong>/…</Text></LayerCard.Primary></LayerCard>
+            <LayerCard><LayerCard.Secondary>{data.reels}</LayerCard.Secondary><LayerCard.Primary><Text variant="secondary" size="base">instagram.com/<strong className="text-kumo-default">reel</strong>(s)/…</Text><Text variant="secondary" size="base">instagram.com/username/<strong className="text-kumo-default">reel</strong>(s)/…</Text></LayerCard.Primary></LayerCard>
+            <LayerCard><LayerCard.Secondary>{data.userProfile}</LayerCard.Secondary><LayerCard.Primary><Text variant="secondary" size="base">instagram.com/<strong className="text-kumo-default">username</strong></Text></LayerCard.Primary></LayerCard>
           </Grid>
           <Banner icon={<Info weight="fill" aria-hidden="true" />} title={data.supportNote} />
         </section>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -20,6 +20,8 @@ p { text-wrap: pretty; }
 .page-main { width: min(100%, 1200px); margin-inline: auto; padding: 0 32px 72px; display: flex; flex-direction: column; gap: 72px; }
 .page-section { display: flex; flex-direction: column; gap: 24px; }
 .usage-grid > * { min-height: 100%; }
+.supported-grid > * { height: 100%; }
+.supported-grid > * > :last-child { flex-grow: 1; }
 .usage-card { height: 100%; }
 .usage-card > :last-child { min-height: 100px; flex-grow: 1; }
 .status-stack { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,6 +1,6 @@
 import { Container } from "@cloudflare/containers";
 import { Hono } from "hono";
-import { botRE, homePathLocale, parseEmbedSegments, resolveHomeLocale, splitPath } from "../shared/routes";
+import { botRE, homePathLocale, parseEmbedSegments, resolveHomeLocale, splitPath, validUsername } from "../shared/routes";
 
 const instagramOrigin = "https://www.instagram.com";
 const defaultCache = (caches as unknown as { default: Cache }).default;
@@ -263,6 +263,18 @@ function resolveContainerRoute(url: URL): ContainerRoute | null {
       cacheKey: `/${gallery ? "gallery" : "embed"}/${embed.postType}/${encodeURIComponent(embed.shortcode)}/${selected ?? "-"}`,
       varyBot: true,
       humanRedirect: origin,
+      rewritePath: gallery ? galleryRewritePath(url) : undefined
+    };
+  }
+
+  // Bare profile: /<username>/
+  if (segments.length === 1 && validUsername(segments[0])) {
+    const username = segments[0];
+    const gallery = isGalleryHost(url);
+    return {
+      cacheKey: `/${gallery ? "pgallery" : "profile"}/${encodeURIComponent(username)}`,
+      varyBot: true,
+      humanRedirect: `${instagramOrigin}/${encodeURIComponent(username)}/`,
       rewritePath: gallery ? galleryRewritePath(url) : undefined
     };
   }


### PR DESCRIPTION
## Summary
Adds rich Instagram **user profile** embeds alongside the existing post/reel support. A single public `web_profile_info` call yields display name, bio, follower/post counts, and recent media — rendered as a Mastodon Account/Status so Discord shows up to 4 recent posts as a gallery (direct CDN media, no origin compositing) plus an avatar summary card.

## Commits
- **refactor(server): instagrapi-faithful error handling and proxy tuning** — reason registry (`rotateIP`/`transient`) driving session rotation, cache TTL, and a two-bucket user card; `raceFetch` prefers the authoritative error (a real 404 beats a rate-limited 401); momentary pool exhaustion isn't cached; race tuned to 3 + 2.
- **feat(server): Instagram user profile embeds** — `web_profile_info` fetch, Mastodon Account/Status rendering, snowcode profile codes, routes `/<username>`, `/users/<username>`, `/users/<username>/statuses/<code>`.
- **feat(web): supported-URL section and profile labels** — Supported URLs reorganized into Posts / Reels / User Profile (equal-height cards, clearer typography).
- **feat(web): content-hash favicons** — favicons hashed at build like `main-<hash>.js/css` so deploys bust icon caches; `/favicon.ico` stays fixed.

## Testing
- `go vet` / `go test` / `tsc` pass.
- Verified live: profile card, Mastodon status gallery, not-found classification, web home rendering, and hashed-favicon serving (immutable cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)