### PR TITLE
Allow www.d. and www.g. subdomains

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -181,11 +181,11 @@ type ContainerRoute = {
 };
 
 function isDirectHost(url: URL): boolean {
-  return url.hostname.startsWith("d.");
+  return url.hostname.startsWith("d.") || url.hostname.startsWith("www.d.");
 }
 
 function isGalleryHost(url: URL): boolean {
-  return url.hostname.startsWith("g.");
+  return url.hostname.startsWith("g.") || url.hostname.startsWith("www.g.");
 }
 
 function resolveContainerRoute(url: URL): ContainerRoute | null {


### PR DESCRIPTION
This will allow users to use the domain and gallery views without deleting the "www." from the copied links.