### PR TITLE
Route www.d. and www.g. custom domains to the worker

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -37,6 +37,14 @@
     {
       "pattern": "g.oginstagram.com",
       "custom_domain": true
+    },
+    {
+      "pattern": "www.d.oginstagram.com",
+      "custom_domain": true
+    },
+    {
+      "pattern": "www.g.oginstagram.com",
+      "custom_domain": true
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
## Summary

PR #8 made the worker recognize `www.d.oginstagram.com` and `www.g.oginstagram.com`, but no route sends those hostnames to the worker, so the feature is unreachable. This adds the two Custom Domain route entries.

Custom Domains create the DNS records and issue certificates on deploy — necessary here because two-level subdomains (`www.d.*`) fall outside the universal `*.oginstagram.com` certificate.

## Testing
- `wrangler deploy --dry-run` validates the configuration cleanly.
- Note for deploy: if conflicting DNS records already exist for these hostnames, Cloudflare will report it at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)